### PR TITLE
Block multi-unit deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__/
 **/.terraform.lock.hcl
 **/*.tfstate*
 **/*.tfvars
+**/smtp_integrator/v0/smtp.py

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ __pycache__/
 **/.terraform.lock.hcl
 **/*.tfstate*
 **/*.tfvars
-**/smtp_integrator/v0/smtp.py

--- a/lib/charms/smtp_integrator/v0/smtp.py
+++ b/lib/charms/smtp_integrator/v0/smtp.py
@@ -1,0 +1,395 @@
+# Copyright 2025 Canonical Ltd.
+# Licensed under the Apache2.0. See LICENSE file in charm source for details.
+
+"""Library to manage the integration with the SMTP Integrator charm.
+
+This library contains the Requires and Provides classes for handling the integration
+between an application and a charm providing the `smtp` and `smtp-legacy` integrations.
+If the requirer charm supports secrets, the preferred approach is to use the `smtp`
+relation to leverage them.
+This library also contains a `SmtpRelationData` class to wrap the SMTP data that will
+be shared via the integration.
+
+### Requirer Charm
+
+```python
+
+from charms.smtp_integrator.v0.smtp import SmtpDataAvailableEvent, SmtpRequires
+
+class SmtpRequirerCharm(ops.CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.smtp = smtp.SmtpRequires(self)
+        self.framework.observe(self.smtp.on.smtp_data_available, self._handler)
+        ...
+
+    def _handler(self, events: SmtpDataAvailableEvent) -> None:
+        ...
+
+```
+
+As shown above, the library provides a custom event to handle the scenario in
+which new SMTP data has been added or updated.
+
+### Provider Charm
+
+Following the previous example, this is an example of the provider charm.
+
+```python
+from charms.smtp_integrator.v0.smtp import SmtpProvides
+
+class SmtpProviderCharm(ops.CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.smtp = SmtpProvides(self)
+        ...
+
+```
+The SmtpProvides object wraps the list of relations into a `relations` property
+and provides an `update_relation_data` method to update the relation data by passing
+a `SmtpRelationData` data object.
+
+```python
+class SmtpProviderCharm(ops.CharmBase):
+    ...
+
+    def _on_config_changed(self, _) -> None:
+        for relation in self.model.relations[self.smtp.relation_name]:
+            self.smtp.update_relation_data(relation, self._get_smtp_data())
+
+```
+"""
+
+# The unique Charmhub library identifier, never change it
+LIBID = "09583c2f9c1d4c0f9a40244cfc20b0c2"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 15
+
+PYDEPS = ["pydantic>=2"]
+
+# pylint: disable=wrong-import-position
+import itertools
+import logging
+import typing
+from ast import literal_eval
+from enum import Enum
+from typing import Dict, Optional
+
+import ops
+from pydantic import BaseModel, Field, ValidationError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RELATION_NAME = "smtp"
+LEGACY_RELATION_NAME = "smtp-legacy"
+
+
+class SmtpError(Exception):
+    """Common ancestor for Smtp related exceptions."""
+
+
+class SecretError(SmtpError):
+    """Common ancestor for Secrets related exceptions."""
+
+
+class TransportSecurity(str, Enum):
+    """Represent the transport security values.
+
+    Attributes:
+        NONE: none
+        STARTTLS: starttls
+        TLS: tls
+    """
+
+    NONE = "none"
+    STARTTLS = "starttls"
+    TLS = "tls"
+
+
+class AuthType(str, Enum):
+    """Represent the auth type values.
+
+    Attributes:
+        NONE: none
+        NOT_PROVIDED: not_provided
+        PLAIN: plain
+    """
+
+    NONE = "none"
+    NOT_PROVIDED = "not_provided"
+    PLAIN = "plain"
+
+
+class SmtpRelationData(BaseModel):
+    """Represent the relation data.
+
+    Attributes:
+        host: The hostname or IP address of the outgoing SMTP relay.
+        port: The port of the outgoing SMTP relay.
+        user: The SMTP AUTH user to use for the outgoing SMTP relay.
+        password: The SMTP AUTH password to use for the outgoing SMTP relay.
+        password_id: The secret ID where the SMTP AUTH password for the SMTP relay is stored.
+        auth_type: The type used to authenticate with the SMTP relay.
+        transport_security: The security protocol to use for the outgoing SMTP relay.
+        domain: The domain used by the emails sent from SMTP relay.
+        skip_ssl_verify: Specifies if certificate trust verification is skipped in the SMTP relay.
+    """
+
+    host: str = Field(..., min_length=1)
+    port: int = Field(..., ge=1, le=65536)
+    user: Optional[str] = None
+    password: Optional[str] = None
+    password_id: Optional[str] = None
+    auth_type: AuthType
+    transport_security: TransportSecurity
+    domain: Optional[str] = None
+    skip_ssl_verify: Optional[bool] = False
+
+    def to_relation_data(self) -> Dict[str, str]:
+        """Convert an instance of SmtpRelationData to the relation representation.
+
+        Returns:
+            Dict containing the representation.
+        """
+        result = {
+            "host": str(self.host),
+            "port": str(self.port),
+            "auth_type": self.auth_type.value,
+            "transport_security": self.transport_security.value,
+            "skip_ssl_verify": str(self.skip_ssl_verify),
+        }
+        if self.domain:
+            result["domain"] = self.domain
+        if self.user:
+            result["user"] = self.user
+        if self.password:
+            result["password"] = self.password
+        if self.password_id:
+            result["password_id"] = self.password_id
+        return result
+
+
+class SmtpDataAvailableEvent(ops.RelationEvent):
+    """Smtp event emitted when relation data has changed.
+
+    Attributes:
+        host: The hostname or IP address of the outgoing SMTP relay.
+        port: The port of the outgoing SMTP relay.
+        user: The SMTP AUTH user to use for the outgoing SMTP relay.
+        password: The SMTP AUTH password to use for the outgoing SMTP relay.
+        password_id: The secret ID where the SMTP AUTH password for the SMTP relay is stored.
+        auth_type: The type used to authenticate with the SMTP relay.
+        transport_security: The security protocol to use for the outgoing SMTP relay.
+        domain: The domain used by the emails sent from SMTP relay.
+        skip_ssl_verify: Specifies if certificate trust verification is skipped in the SMTP relay.
+    """
+
+    @property
+    def host(self) -> str:
+        """Fetch the SMTP host from the relation."""
+        assert self.relation.app
+        return typing.cast(str, self.relation.data[self.relation.app].get("host"))
+
+    @property
+    def port(self) -> int:
+        """Fetch the SMTP port from the relation."""
+        assert self.relation.app
+        return int(typing.cast(str, self.relation.data[self.relation.app].get("port")))
+
+    @property
+    def user(self) -> str:
+        """Fetch the SMTP user from the relation."""
+        assert self.relation.app
+        return typing.cast(str, self.relation.data[self.relation.app].get("user"))
+
+    @property
+    def password(self) -> str:
+        """Fetch the SMTP password from the relation."""
+        assert self.relation.app
+        return typing.cast(str, self.relation.data[self.relation.app].get("password"))
+
+    @property
+    def password_id(self) -> str:
+        """Fetch the SMTP password from the relation."""
+        assert self.relation.app
+        return typing.cast(str, self.relation.data[self.relation.app].get("password_id"))
+
+    @property
+    def auth_type(self) -> AuthType:
+        """Fetch the SMTP auth type from the relation."""
+        assert self.relation.app
+        return AuthType(self.relation.data[self.relation.app].get("auth_type"))
+
+    @property
+    def transport_security(self) -> TransportSecurity:
+        """Fetch the SMTP transport security protocol from the relation."""
+        assert self.relation.app
+        return TransportSecurity(self.relation.data[self.relation.app].get("transport_security"))
+
+    @property
+    def domain(self) -> str:
+        """Fetch the SMTP domain from the relation."""
+        assert self.relation.app
+        return typing.cast(str, self.relation.data[self.relation.app].get("domain"))
+
+    @property
+    def skip_ssl_verify(self) -> bool:
+        """Fetch the skip_ssl_verify flag from the relation."""
+        assert self.relation.app
+        return literal_eval(
+            typing.cast(str, self.relation.data[self.relation.app].get("skip_ssl_verify"))
+        )
+
+
+class SmtpRequiresEvents(ops.CharmEvents):
+    """SMTP events.
+
+    This class defines the events that a SMTP requirer can emit.
+
+    Attributes:
+        smtp_data_available: the SmtpDataAvailableEvent.
+    """
+
+    smtp_data_available = ops.EventSource(SmtpDataAvailableEvent)
+
+
+class SmtpRequires(ops.Object):
+    """Requirer side of the SMTP relation.
+
+    Attributes:
+        on: events the provider can emit.
+    """
+
+    on = SmtpRequiresEvents()
+
+    def __init__(self, charm: ops.CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
+        """Construct.
+
+        Args:
+            charm: the provider charm.
+            relation_name: the relation name.
+        """
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+
+    def get_relation_data(self) -> Optional[SmtpRelationData]:
+        """Retrieve the relation data.
+
+        Returns:
+            SmtpRelationData: the relation data.
+        """
+        relation = self.model.get_relation(self.relation_name)
+        return self._get_relation_data_from_relation(relation) if relation else None
+
+    def _get_relation_data_from_relation(
+        self, relation: ops.Relation
+    ) -> Optional[SmtpRelationData]:
+        """Retrieve the relation data.
+
+        Args:
+            relation: the relation to retrieve the data from.
+
+        Returns:
+            SmtpRelationData: the relation data.
+        """
+        assert relation.app
+        relation_data = relation.data[relation.app]
+        if not relation_data:
+            return None
+
+        password = relation_data.get("password")
+        if password is None and relation_data.get("password_id"):
+            try:
+                password = (
+                    self.model.get_secret(id=relation_data.get("password_id"))
+                    .get_content()
+                    .get("password")
+                )
+            except ops.model.ModelError as exc:
+                raise SecretError(
+                    f"Could not consume secret {relation_data.get('password_id')}"
+                ) from exc
+
+        return SmtpRelationData(
+            host=typing.cast(str, relation_data.get("host")),
+            port=typing.cast(int, relation_data.get("port")),
+            user=relation_data.get("user"),
+            password=password,
+            password_id=relation_data.get("password_id"),
+            auth_type=AuthType(relation_data.get("auth_type")),
+            transport_security=TransportSecurity(relation_data.get("transport_security")),
+            domain=relation_data.get("domain"),
+            skip_ssl_verify=typing.cast(bool, relation_data.get("skip_ssl_verify")),
+        )
+
+    def _is_relation_data_valid(self, relation: ops.Relation) -> bool:
+        """Validate the relation data.
+
+        Args:
+            relation: the relation to validate.
+
+        Returns:
+            true: if the relation data is valid.
+        """
+        try:
+            _ = self._get_relation_data_from_relation(relation)
+            return True
+        except ValidationError as ex:
+            error_fields = set(
+                itertools.chain.from_iterable(error["loc"] for error in ex.errors())
+            )
+            error_field_str = " ".join(f"{f}" for f in error_fields)
+            logger.warning("Error validation the relation data %s", error_field_str)
+            return False
+
+    def _on_relation_changed(self, event: ops.RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed.
+
+        Args:
+            event: event triggering this handler.
+        """
+        assert event.relation.app
+        relation_data = event.relation.data[event.relation.app]
+        if relation_data:
+            if relation_data["auth_type"] == AuthType.NONE.value:
+                logger.warning('Insecure setting: auth_type has a value "none"')
+            if relation_data["transport_security"] == TransportSecurity.NONE.value:
+                logger.warning('Insecure setting: transport_security has value "none"')
+            if self._is_relation_data_valid(event.relation):
+                self.on.smtp_data_available.emit(event.relation, app=event.app, unit=event.unit)
+
+
+class SmtpProvides(ops.Object):
+    """Provider side of the SMTP relation."""
+
+    def __init__(self, charm: ops.CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
+        """Construct.
+
+        Args:
+            charm: the provider charm.
+            relation_name: the relation name.
+        """
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+    def update_relation_data(self, relation: ops.Relation, smtp_data: SmtpRelationData) -> None:
+        """Update the relation data.
+
+        Args:
+            relation: the relation for which to update the data.
+            smtp_data: a SmtpRelationData instance wrapping the data to be updated.
+        """
+        relation_data = smtp_data.to_relation_data()
+        if relation_data["auth_type"] == AuthType.NONE.value:
+            logger.warning('Insecure setting: auth_type has a value "none"')
+        if relation_data["transport_security"] == TransportSecurity.NONE.value:
+            logger.warning('Insecure setting: transport_security has value "none"')
+        relation.data[self.charm.model.app].update(relation_data)

--- a/lib/charms/traefik_k8s/v2/ingress.py
+++ b/lib/charms/traefik_k8s/v2/ingress.py
@@ -57,7 +57,18 @@ import socket
 import typing
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Dict, List, MutableMapping, Optional, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
 
 import pydantic
 from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
@@ -73,7 +84,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 14
+LIBPATCH = 15
 
 PYDEPS = ["pydantic"]
 
@@ -226,7 +237,7 @@ class IngressUrl(BaseModel):
 class IngressProviderAppData(DatabagModel):
     """Ingress application databag schema."""
 
-    ingress: IngressUrl
+    ingress: Optional[IngressUrl] = None
 
 
 class ProviderSchema(BaseModel):
@@ -235,12 +246,32 @@ class ProviderSchema(BaseModel):
     app: IngressProviderAppData
 
 
+class IngressHealthCheck(BaseModel):
+    """HealthCheck schema for Ingress."""
+
+    path: str = Field(description="The health check endpoint path (required).")
+    scheme: Optional[str] = Field(
+        default=None, description="Replaces the server URL scheme for the health check endpoint."
+    )
+    hostname: Optional[str] = Field(
+        default=None, description="Hostname to be set in the health check request."
+    )
+    port: Optional[int] = Field(
+        default=None, description="Replaces the server URL port for the health check endpoint."
+    )
+    interval: str = Field(default="30s", description="Frequency of the health check calls.")
+    timeout: str = Field(default="5s", description="Maximum duration for a health check request.")
+
+
 class IngressRequirerAppData(DatabagModel):
     """Ingress requirer application databag model."""
 
     model: str = Field(description="The model the application is in.")
     name: str = Field(description="the name of the app requesting ingress.")
     port: int = Field(description="The port the app wishes to be exposed.")
+    healthcheck_params: Optional[IngressHealthCheck] = Field(
+        default=None, description="Optional health check configuration for ingress."
+    )
 
     # fields on top of vanilla 'ingress' interface:
     strip_prefix: Optional[bool] = Field(
@@ -558,7 +589,16 @@ class IngressPerAppProvider(_IngressPerAppBase):
     def publish_url(self, relation: Relation, url: str):
         """Publish to the app databag the ingress url."""
         ingress_url = {"url": url}
-        IngressProviderAppData(ingress=ingress_url).dump(relation.data[self.app])  # type: ignore
+        try:
+            IngressProviderAppData(ingress=ingress_url).dump(relation.data[self.app])  # type: ignore
+        except pydantic.ValidationError as e:
+            # If we cannot validate the url as valid, publish an empty databag and log the error.
+            log.error(f"Failed to validate ingress url '{url}' - got ValidationError {e}")
+            log.error(
+                "url was not published to ingress relation for {relation.app}.  This error is likely due to an"
+                " error or misconfiguration of the charm calling this library."
+            )
+            IngressProviderAppData(ingress=None).dump(relation.data[self.app])  # type: ignore
 
     @property
     def proxied_endpoints(self) -> Dict[str, Dict[str, str]]:
@@ -596,10 +636,14 @@ class IngressPerAppProvider(_IngressPerAppBase):
             if not ingress_data:
                 log.warning(f"relation {ingress_relation} not ready yet: try again in some time.")
                 continue
+
+            # Validation above means ingress cannot be None, but type checker doesn't know that.
+            ingress = ingress_data.ingress
+            ingress = cast(IngressProviderAppData, ingress)
             if PYDANTIC_IS_V1:
-                results[ingress_relation.app.name] = ingress_data.ingress.dict()
+                results[ingress_relation.app.name] = ingress.dict()
             else:
-                results[ingress_relation.app.name] = ingress_data.ingress.model_dump(mode="json")
+                results[ingress_relation.app.name] = ingress.model_dump(mode="json")
         return results
 
 
@@ -644,6 +688,7 @@ class IngressPerAppRequirer(_IngressPerAppBase):
         # fixme: this is horrible UX.
         #  shall we switch to manually calling provide_ingress_requirements with all args when ready?
         scheme: Union[Callable[[], str], str] = lambda: "http",
+        healthcheck_params: Optional[Dict[str, Any]] = None,
     ):
         """Constructor for IngressRequirer.
 
@@ -653,23 +698,34 @@ class IngressPerAppRequirer(_IngressPerAppBase):
         All request args must be given as keyword args.
 
         Args:
-            charm: the charm that is instantiating the library.
-            relation_name: the name of the relation endpoint to bind to (defaults to `ingress`);
-                relation must be of interface type `ingress` and have "limit: 1")
+            charm: The charm that is instantiating the library.
+            relation_name: The name of the relation endpoint to bind to (defaults to "ingress");
+                the relation must be of interface type "ingress" and have a limit of 1.
             host: Hostname to be used by the ingress provider to address the requiring
                 application; if unspecified, the default Kubernetes service name will be used.
             ip: Alternative addressing method other than host to be used by the ingress provider;
-                if unspecified, binding address from juju network API will be used.
-            strip_prefix: configure Traefik to strip the path prefix.
-            redirect_https: redirect incoming requests to HTTPS.
-            scheme: callable returning the scheme to use when constructing the ingress url.
-                Or a string, if the scheme is known and stable at charm-init-time.
+                if unspecified, the binding address from the Juju network API will be used.
+            healthcheck_params: Optional dictionary containing health check
+                configuration parameters conforming to the IngressHealthCheck schema. The dictionary must include:
+                    - "path" (str): The health check endpoint path (required).
+                It may also include:
+                    - "scheme" (Optional[str]): Replaces the server URL scheme for the health check endpoint.
+                    - "hostname" (Optional[str]): Hostname to be set in the health check request.
+                    - "port" (Optional[int]): Replaces the server URL port for the health check endpoint.
+                    - "interval" (str): Frequency of the health check calls (defaults to "30s" if omitted).
+                    - "timeout" (str): Maximum duration for a health check request (defaults to "5s" if omitted).
+                If provided, "path" is required while "interval" and "timeout" will use Traefik's defaults when not specified.
+            strip_prefix: Configure Traefik to strip the path prefix.
+            redirect_https: Redirect incoming requests to HTTPS.
+            scheme: Either a callable that returns the scheme to use when constructing the ingress URL,
+                or a string if the scheme is known and stable at charm initialization.
 
         Request Args:
             port: the port of the service
         """
         super().__init__(charm, relation_name)
         self.charm: CharmBase = charm
+        self.healthcheck_params = healthcheck_params
         self.relation_name = relation_name
         self._strip_prefix = strip_prefix
         self._redirect_https = redirect_https
@@ -801,6 +857,11 @@ class IngressPerAppRequirer(_IngressPerAppBase):
                 port=port,
                 strip_prefix=self._strip_prefix,  # type: ignore  # pyright does not like aliases
                 redirect_https=self._redirect_https,  # type: ignore  # pyright does not like aliases
+                healthcheck_params=(
+                    IngressHealthCheck(**self.healthcheck_params)
+                    if self.healthcheck_params
+                    else None
+                ),
             ).dump(app_databag)
         except pydantic.ValidationError as e:
             msg = "failed to validate app data"
@@ -834,7 +895,11 @@ class IngressPerAppRequirer(_IngressPerAppBase):
         if not databag:  # not ready yet
             return None
 
-        return str(IngressProviderAppData.load(databag).ingress.url)
+        ingress = IngressProviderAppData.load(databag).ingress
+        if ingress is None:
+            return None
+
+        return str(ingress.url)
 
     @property
     def url(self) -> Optional[str]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ops==2.19.4
-paas-charm==1.4.0
+paas-charm==1.4.1
 requests==2.32.3

--- a/src/charm.py
+++ b/src/charm.py
@@ -30,6 +30,14 @@ class HockeypuckK8SCharm(paas_charm.go.Charm):
         self.actions_observer = actions.Observer(self)
         self._traefik_route = traefik_route_observer.TraefikRouteObserver(self)
 
+    def is_ready(self) -> bool:
+        if len(self.model.get_relation("secret-storage").units) > 0:
+            self.update_app_and_unit_status(
+                ops.BlockedStatus("Hockeypuck does not support multi-unit deployments")
+            )
+            return False
+        return super().is_ready()
+
     def restart(self, rerun_migrations: bool = False) -> None:
         """Open reconciliation port and call the parent restart method.
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -31,7 +31,12 @@ class HockeypuckK8SCharm(paas_charm.go.Charm):
         self._traefik_route = traefik_route_observer.TraefikRouteObserver(self)
 
     def is_ready(self) -> bool:
-        if len(self.model.get_relation("secret-storage").units) > 0:
+        """Check if the charm is ready to start the workload application.
+
+        Returns:
+            True if the charm is ready to start the workload application.
+        """
+        if self.model.app.planned_units() > 1:
             self.update_app_and_unit_status(
                 ops.BlockedStatus("Hockeypuck does not support multi-unit deployments")
             )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -45,6 +45,7 @@ async def postgresql_app_fixture(
         channel="14/stable",
         trust=True,
     )
+    await model.wait_for_idle(status="active", apps=[app.name])
     return app
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -113,8 +113,8 @@ async def test_unit_limit(hockeypuck_k8s_app: Application) -> None:
     assert (
         hockeypuck_k8s_app.status_message == "Hockeypuck does not support multi-unit deployments"
     )
-    hockeypuck_k8s_app.scale(1)
-    await hockeypuck_k8s_app.wait_for_idle(status="active", apps=[hockeypuck_k8s_app.name])
+    await hockeypuck_k8s_app.scale(scale=1)
+    await hockeypuck_k8s_app.model.wait_for_idle(status="active", apps=[hockeypuck_k8s_app.name])
     assert hockeypuck_k8s_app.status == "active"
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -16,6 +16,7 @@ import requests
 from gnupg import GPG
 from juju.application import Application
 from juju.client._definitions import UnitStatus
+from juju.unit import Unit
 
 from actions import HTTP_PORT, RECONCILIATION_PORT
 
@@ -112,7 +113,7 @@ async def test_unit_limit(hockeypuck_k8s_app: Application) -> None:
     assert (
         hockeypuck_k8s_app.status_message == "Hockeypuck does not support multi-unit deployments"
     )
-    await hockeypuck_k8s_app.destroy_unit(f"{hockeypuck_k8s_app.name}/1")
+    hockeypuck_k8s_app.scale(1)
     await hockeypuck_k8s_app.wait_for_idle(status="active", apps=[hockeypuck_k8s_app.name])
     assert hockeypuck_k8s_app.status == "active"
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -112,7 +112,8 @@ async def test_unit_limit(hockeypuck_k8s_app: Application) -> None:
     assert (
         hockeypuck_k8s_app.status_message == "Hockeypuck does not support multi-unit deployments"
     )
-    await hockeypuck_k8s_app.remove_unit(status="active", apps=[hockeypuck_k8s_app.name])
+    await hockeypuck_k8s_app.destroy_unit(f"{hockeypuck_k8s_app.name}/1")
+    await hockeypuck_k8s_app.wait_for_idle(status="active", apps=[hockeypuck_k8s_app.name])
     assert hockeypuck_k8s_app.status == "active"
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -16,7 +16,6 @@ import requests
 from gnupg import GPG
 from juju.application import Application
 from juju.client._definitions import UnitStatus
-from juju.unit import Unit
 
 from actions import HTTP_PORT, RECONCILIATION_PORT
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -107,12 +107,12 @@ async def test_unit_limit(hockeypuck_k8s_app: Application) -> None:
     assert: The application is blocked.
     """
     await hockeypuck_k8s_app.add_unit()
-    await hockeypuck_k8s_app.model.wait_for_idle()
+    await hockeypuck_k8s_app.model.wait_for_idle(status="blocked")
     assert hockeypuck_k8s_app.status == "blocked"
     assert (
         hockeypuck_k8s_app.status_message == "Hockeypuck does not support multi-unit deployments"
     )
-    await hockeypuck_k8s_app.remove_unit()
+    await hockeypuck_k8s_app.remove_unit(status="active")
     assert hockeypuck_k8s_app.status == "active"
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -112,6 +112,8 @@ async def test_unit_limit(hockeypuck_k8s_app: Application) -> None:
     assert (
         hockeypuck_k8s_app.status_message == "Hockeypuck does not support multi-unit deployments"
     )
+    await hockeypuck_k8s_app.remove_unit()
+    assert hockeypuck_k8s_app.status == "active"
 
 
 @pytest.mark.usefixtures("external_peer_config")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -100,6 +100,20 @@ async def test_lookup_key_not_found(hockeypuck_k8s_app: Application) -> None:
     assert "Not Found" in action.results["stderr"]
 
 
+async def test_unit_limit(hockeypuck_k8s_app: Application) -> None:
+    """
+    arrange: Deploy the Hockeypuck charm.
+    act: Add a unit to the application.
+    assert: The application is blocked.
+    """
+    await hockeypuck_k8s_app.add_unit()
+    await hockeypuck_k8s_app.model.wait_for_idle()
+    assert hockeypuck_k8s_app.status == "blocked"
+    assert (
+        hockeypuck_k8s_app.status_message == "Hockeypuck does not support multi-unit deployments"
+    )
+
+
 @pytest.mark.usefixtures("external_peer_config")
 @pytest.mark.dependency(depends=["test_adding_records"])
 @pytest.mark.flaky(reruns=10, reruns_delay=10)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -107,12 +107,12 @@ async def test_unit_limit(hockeypuck_k8s_app: Application) -> None:
     assert: The application is blocked.
     """
     await hockeypuck_k8s_app.add_unit()
-    await hockeypuck_k8s_app.model.wait_for_idle(status="blocked")
+    await hockeypuck_k8s_app.model.wait_for_idle(status="blocked", apps=[hockeypuck_k8s_app.name])
     assert hockeypuck_k8s_app.status == "blocked"
     assert (
         hockeypuck_k8s_app.status_message == "Hockeypuck does not support multi-unit deployments"
     )
-    await hockeypuck_k8s_app.remove_unit(status="active")
+    await hockeypuck_k8s_app.remove_unit(status="active", apps=[hockeypuck_k8s_app.name])
     assert hockeypuck_k8s_app.status == "active"
 
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
- Block the charm when number of units > 1 

### Rationale

<!-- The reason the change is needed -->
Hockeypuck stores a local leveldb database inside the unit which becomes inconsistent when multiple units are deployed.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
Charmhub will be updated in the documentation task
