### PR TITLE
Add back changelog after docs init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+docs/changelog.md

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Each revision is versioned by the date of the revision.
+
+## 2025-04-16
+
+### Added
+
+- Changelog added for tracking changes.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Add back changelog after the docs directory is initialized.

### Rationale

<!-- The reason the change is needed -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
