### PR TITLE
Change publish charm track from latest to 2.2

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -7,13 +7,11 @@ on:
         type: choice
         description: 'Origin Channel'
         options:
-        - latest/edge
         - 2.2/edge
       destination-channel:
         type: choice
         description: 'Destination Channel'
         options:
-        - 2.2/edge
         - 2.2/stable
     secrets:
       CHARMHUB_TOKEN:

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -11,5 +11,5 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
     secrets: inherit
     with:
-      channel: latest/edge
+      channel: 2.2/edge
       resource-mapping: '{"hockeypuck": "app-image"}'

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2025-04-24
 
-### Modifed
+### Modified
 
 - Modified publish charm workflow to use `2.2/edge` track instead of `latest/edge`
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-04-24
+
+### Modifed
+
+- Modified publish charm workflow to use `2.2/edge` track instead of `latest/edge`
+
 ## 2025-04-21
 
 ### Added


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Ensuring that every PR pushes to 2.2/edge automatically to comply with [charm publication rules](https://canonical-platform-engineering.readthedocs-hosted.com/en/latest/engineering-practices/charm-development/charm-publication/).

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
