### PR TITLE
fix: use local WORKLOAD_CONTAINER_NAME (regression in paas_charm)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-05-27
+
+- Use a local constant for workload container name instead of reading it from upstream paas-charm.
+
 ## 2025-05-22
 
 - Fix broken links found in Charmhub docs.

--- a/src/actions.py
+++ b/src/actions.py
@@ -12,9 +12,9 @@ import paas_app_charmer.go
 import requests
 from requests.exceptions import RequestException
 
-WORKLOAD_CONTAINER_NAME = "app"
-
 from admin_gpg import AdminGPG
+
+WORKLOAD_CONTAINER_NAME = "app"
 
 logger = logging.getLogger(__name__)
 

--- a/src/actions.py
+++ b/src/actions.py
@@ -10,8 +10,9 @@ import typing
 import ops
 import paas_app_charmer.go
 import requests
-from paas_charm.go.charm import WORKLOAD_CONTAINER_NAME
 from requests.exceptions import RequestException
+
+WORKLOAD_CONTAINER_NAME = "app"
 
 from admin_gpg import AdminGPG
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Use a local constant for workload container name instead of reading it from upstream paas-charm.
<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->
The `WORKLOAD_CONTAINER_NAME` constant imported in hockeypuck from paas_charm has been removed in this [PR](https://github.com/canonical/paas-charm/pull/61/files#diff-d31cb126673652b5c1f7d52e55051e7e08de4b627a26f278196ad3d1096f7b5d) in the upstream code, causing the CI to fail. 

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
