### PR TITLE
chore: unpin flake8 dependencies

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,5 +14,6 @@ jobs:
       self-hosted-runner-label: "edge"
       juju-channel: '3.6/stable'
       channel: '1.32-strict/stable'
+      self-hosted-runner-image: jammy
       pre-run-script: |
         -c "./tests/integration/pre_run_script.sh"

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,6 +14,5 @@ jobs:
       self-hosted-runner-label: "edge"
       juju-channel: '3.6/stable'
       channel: '1.32-strict/stable'
-      self-hosted-runner-image: jammy
       pre-run-script: |
         -c "./tests/integration/pre_run_script.sh"

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,6 +13,6 @@ jobs:
       self-hosted-runner: true
       self-hosted-runner-label: "edge"
       juju-channel: '3.6/stable'
-      channel: '1.32-strict/stable'
+      channel: '1.34-strict/stable'
       pre-run-script: |
         -c "./tests/integration/pre_run_script.sh"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ paas-charm==1.8.6
 passlib==1.7.4
 python-gnupg==0.5.5
 requests==2.32.5
+setuptools==80.9.0

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -137,7 +137,7 @@ def gpg_key_fixture() -> Any:
     )
     key = gpg.gen_key(input_data)
     if not key.fingerprint:
-        raise RuntimeError(f"GPG key generation failed.")
+        raise RuntimeError("GPG key generation failed.")
     return key
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -132,6 +132,8 @@ def gpg_key_fixture() -> Any:
         name_real="Test User", name_email="test@gmail.com", passphrase=password
     )
     key = gpg.gen_key(input_data)
+    if not key.fingerprint:
+        raise RuntimeError(f"GPG key generation failed: {key.stderr}")
     return key
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -131,8 +131,8 @@ def gpg_key_fixture() -> Any:
     input_data = gpg.gen_key_input(
         key_type="RSA",
         key_length=2048,
-        name_real="Test User", 
-        name_email="test@gmail.com", 
+        name_real="Test User",
+        name_email="test@gmail.com",
         passphrase=password
     )
     key = gpg.gen_key(input_data)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -129,11 +129,15 @@ def gpg_key_fixture() -> Any:
     gpg = gnupg.GPG()
     password = genword(length=10)
     input_data = gpg.gen_key_input(
-        name_real="Test User", name_email="test@gmail.com", passphrase=password
+        key_type="RSA",
+        key_length=2048,
+        name_real="Test User", 
+        name_email="test@gmail.com", 
+        passphrase=password
     )
     key = gpg.gen_key(input_data)
     if not key.fingerprint:
-        raise RuntimeError(f"GPG key generation failed: {key.stderr}")
+        raise RuntimeError(f"GPG key generation failed: {key}. Fingerprint: {key.fingerprint}.")
     return key
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -133,7 +133,7 @@ def gpg_key_fixture() -> Any:
         key_length=2048,
         name_real="Test User",
         name_email="test@gmail.com",
-        passphrase=password
+        passphrase=password,
     )
     key = gpg.gen_key(input_data)
     if not key.fingerprint:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -137,7 +137,7 @@ def gpg_key_fixture() -> Any:
     )
     key = gpg.gen_key(input_data)
     if not key.fingerprint:
-        raise RuntimeError(f"GPG key generation failed: {key}. Fingerprint: {key.fingerprint}.")
+        raise RuntimeError(f"GPG key generation failed.")
     return key
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -48,9 +48,7 @@ async def test_adding_records(gpg_key: Any, hockeypuck_url: str) -> None:
     """
     gpg = GPG()
     fingerprint = gpg_key.fingerprint
-    assert fingerprint, "Generated key has no fingerprint"
     public_key = gpg.export_keys(fingerprint)
-    assert "BEGIN PGP PUBLIC KEY BLOCK" in public_key, "No public key exported"
     response = requests.post(
         f"{hockeypuck_url}/pks/add",
         timeout=20,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -47,8 +47,10 @@ async def test_adding_records(gpg_key: Any, hockeypuck_url: str) -> None:
     assert: API is added successfully and lookup of key returns the key.
     """
     gpg = GPG()
+    assert fingerprint, "Generated key has no fingerprint"
     fingerprint = gpg_key.fingerprint
     public_key = gpg.export_keys(fingerprint)
+    assert "BEGIN PGP PUBLIC KEY BLOCK" in public_key, "No public key exported"
     response = requests.post(
         f"{hockeypuck_url}/pks/add",
         timeout=20,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -47,8 +47,8 @@ async def test_adding_records(gpg_key: Any, hockeypuck_url: str) -> None:
     assert: API is added successfully and lookup of key returns the key.
     """
     gpg = GPG()
-    assert fingerprint, "Generated key has no fingerprint"
     fingerprint = gpg_key.fingerprint
+    assert fingerprint, "Generated key has no fingerprint"
     public_key = gpg.export_keys(fingerprint)
     assert "BEGIN PGP PUBLIC KEY BLOCK" in public_key, "No public key exported"
     response = requests.post(

--- a/tox.ini
+++ b/tox.ini
@@ -36,12 +36,12 @@ description = Check code against coding style standards
 deps =
     black
     codespell
-    flake8<6.0.0
+    flake8
     flake8-builtins
-    flake8-copyright<6.0.0
-    flake8-docstrings>=1.6.0
-    flake8-docstrings-complete>=1.0.3
-    flake8-test-docs>=1.0
+    flake8-copyright
+    flake8-docstrings
+    flake8-docstrings-complete
+    flake8-test-docs
     gnupg
     isort
     mypy
@@ -49,7 +49,7 @@ deps =
     psycopg2-binary
     pydocstyle>=2.10
     pylint
-    pyproject-flake8<6.0.0
+    pyproject-flake8
     pytest
     pytest-asyncio
     pytest-operator


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Unpin flake8 plugin dependency versions
<!-- A high level overview of the change -->

### Rationale

- To update the flake8 plugins which should then be compatible with Python 3.12 on noble runners.
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

No user relevant changes

<!-- Explanation for any unchecked items above -->
