### PR TITLE
docs: Add landing pages for reference and how-to sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ The following actions are available for this charm:
 * **rebuild-prefix-tree**: Rebuild the prefix tree used by Hockeypuck.
 * **lookup-key**: Look up a key by fingerprint / email-id / keyword.
 
-You can obtain more information on the actions [here](https://charmhub.io/hockeypuck-k8s/actions).
+You can obtain more information on the [Hockeypuck actions page](https://charmhub.io/hockeypuck-k8s/actions).
 
 ## Learn more
 
-- [Read more](https://charmhub.io/hockeypuck-k8s/docs)
+- [Hockeypuck documentation](https://charmhub.io/hockeypuck-k8s/docs)
 - [Official Webpage](https://hockeypuck.io/)
 - [Troubleshooting](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-04-16
+
+- Added landing pages for How-to and Reference documentation sections.
+
 ## 2025-12-17
 
 - Moved charm-architecture.md from Explanation to Reference category.

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,0 +1,28 @@
+# How-to guides
+
+The following guides cover key processes and common tasks for managing and using the Hockeypuck charm.
+
+## Key management
+
+Hockeypuck manages OpenPGP public keys, and the charm provides tools for both regular key operations and administrative key management. These guides explain how to manage keys through Juju actions and HTTP APIs, as well as how to configure admin keys for privileged operations like replacing or deleting keys.
+
+- [Manage GPG keys](manage-gpg-keys.md)
+- [Manage admin keys](manage-admin-keys.md)
+
+## Integration and synchronisation
+
+Hockeypuck can be integrated with the Canonical Observability Stack (COS) for monitoring and with other SKS-compatible key servers for synchronising public key data. These guides walk you through setting up those integrations.
+
+- [Integrate with COS](integrate-with-cos.md)
+- [Reconcile between two key servers](reconcile-between-two-keyservers.md)
+
+## Update and maintenance
+
+Over the lifecycle of your deployment, you may need to upgrade to a newer version of the charm or recover from a failure. These guides cover backing up and restoring Hockeypuck data via the PostgreSQL charm and upgrading to a new charm revision.
+
+- [Back up and restore](backup-and-restore-hockeypuck.md)
+- [Upgrade](upgrade.md)
+
+## Development
+
+- [Contribute](contribute.md)

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "How-to guides for Hockeypuck charm, including basic operations, upgrades, and development."
+---
+
 # How-to guides
 
 The following guides cover key processes and common tasks for managing and using the Hockeypuck charm.
@@ -16,13 +22,10 @@ Hockeypuck can be integrated with the Canonical Observability Stack (COS) for mo
 - [Integrate with COS](integrate-with-cos.md)
 - [Reconcile between two key servers](reconcile-between-two-keyservers.md)
 
-## Update and maintenance
+## Maintenance and development
 
-Over the lifecycle of your deployment, you may need to upgrade to a newer version of the charm or recover from a failure. These guides cover backing up and restoring Hockeypuck data via the PostgreSQL charm and upgrading to a new charm revision.
+Over the lifecycle of your deployment, you may need to upgrade to a newer version of the charm, recover from a failure, or even contribute new features or bug fixes. These guides cover backing up and restoring Hockeypuck data via the PostgreSQL charm, upgrading to a new charm revision, and contributing to the project.
 
 - [Back up and restore](backup-and-restore-hockeypuck.md)
 - [Upgrade](upgrade.md)
-
-## Development
-
 - [Contribute](contribute.md)

--- a/docs/how-to/manage-gpg-keys.md
+++ b/docs/how-to/manage-gpg-keys.md
@@ -30,8 +30,8 @@ The Hockeypuck server also provides a set of SKS-compatible endpoints for intera
 Retrieve key information by fingerprint, name, or email.
 
 **Query Parameters:**
-- op: The operation type, e.g., `get`, `vindex`, or `index`.
-- search: The search term (e.g., key ID, fingerprint, email, or name).
+- op: The operation type, such as `get`, `vindex`, or `index`.
+- search: The search term (such as key ID, fingerprint, email, or name).
 - fingerprint: Optional. If on, returns full fingerprints instead of short key IDs.
 
 **Example:**

--- a/docs/how-to/reconcile-between-two-keyservers.md
+++ b/docs/how-to/reconcile-between-two-keyservers.md
@@ -7,8 +7,8 @@ Hockeypuck supports peering with other SKS-compatible key servers to synchronize
 <peer_address>,<http_port>,<reconciliation_port>
 ```
 * `peer_address`: The IP or fully qualified domain name (FQDN) of the peer.
-* `http_port`: The port where the peer exposes its SKS HTTP API (usually 11371).
-* `reconciliation_port`: The port used for reconciliation (usually 11370).
+* `http_port`: The port where the peer exposes its SKS HTTP API (usually `11371`).
+* `reconciliation_port`: The port used for reconciliation (usually `11370`).
 
 Example `peers.txt`:
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,8 @@ For DevOps and SRE teams, this charm will make operating Hockeypuck simple and s
 
 | | |
 |--|--|
-|  [Tutorials](https://charmhub.io/hockeypuck-k8s/docs/tutorial-getting-started)</br>  Get started - a hands-on introduction to using the charm for new users </br> |  [How-to guides](https://charmhub.io/hockeypuck-k8s/docs/how-to-contribute) </br> Step-by-step guides covering key operations and common tasks |
-| [Reference](https://charmhub.io/hockeypuck-k8s/docs/reference-actions) </br> Technical information - specifications, APIs, architecture | [Explanation](https://charmhub.io/hockeypuck-k8s/docs/explanation-charm-architecture) </br> Concepts - discussion and clarification of key topics  |
+|  [Tutorials](https://charmhub.io/hockeypuck-k8s/docs/tutorial-getting-started)</br>  Get started - a hands-on introduction to using the charm for new users </br> |  [How-to guides](https://charmhub.io/hockeypuck-k8s/docs/how-to-index) </br> Step-by-step guides covering key operations and common tasks |
+| [Reference](https://charmhub.io/hockeypuck-k8s/docs/reference-index) </br> Technical information - specifications, APIs, architecture | [Explanation](https://charmhub.io/hockeypuck-k8s/docs/explanation-charm-architecture) </br> Concepts - discussion and clarification of key topics  |
 
 ## Contributing to this documentation
 
@@ -43,7 +43,7 @@ Thinking about using the Hockeypuck Kubernetes operator for your next project?
 1. [Changelog](changelog.md)
 1. [Explanation](explanation)
   1. [Security](explanation/security.md)
-1. [How To](how-to)
+1. [How To](how-to/index.md)
   1. [Back up and restore](how-to/backup-and-restore-hockeypuck.md)
   1. [How to contribute](how-to/contribute.md)
   1. [Integrate with COS](how-to/integrate-with-cos.md)
@@ -51,7 +51,7 @@ Thinking about using the Hockeypuck Kubernetes operator for your next project?
   1. [Manage GPG keys](how-to/manage-gpg-keys.md)
   1. [Reconcile between two key servers](how-to/reconcile-between-two-keyservers.md)
   1. [Upgrade](how-to/upgrade.md)
-1. [Reference](reference)
+1. [Reference](reference/index.md)
   1. [Actions](reference/actions.md)
   1. [Charm architecture](reference/charm-architecture.md)
   1. [Configurations](reference/configurations.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,19 @@
+# Reference
+
+This section contains technical details and specifications for the Hockeypuck charm.
+
+## Charm usage
+
+The following pages provide more information about the charm's features, including the available Juju actions, configuration options, and relation endpoints.
+
+- [Actions](actions.md)
+- [Configurations](configurations.md)
+- [Integrations](integrations.md)
+
+## Architecture and deployment
+
+The following pages provide more details about the charm's internal architecture, the ports it exposes, and the Prometheus-compatible metrics it provides for monitoring.
+
+- [Charm architecture](charm-architecture.md)
+- [Ports](ports.md)
+- [Metrics](metrics.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Technical information related to the Hockeypuck charm, including actions, configurations, and architecture."
+---
+
 # Reference
 
 This section contains technical details and specifications for the Hockeypuck charm.

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -49,8 +49,7 @@ _Supported charms_: [nginx-ingress-integrator](https://charmhub.io/nginx-ingress
 
 Ingress manages external HTTP/HTTPS access to services in a Kubernetes cluster.
 Note that the Kubernetes cluster must already have an nginx ingress controller deployed. 
-Documentation to enable ingress in MicroK8s can be found 
-[here](https://microk8s.io/docs/addon-ingress).
+See the [MicroK8s ingress documentation](https://microk8s.io/docs/addon-ingress) for instructions on enabling ingress.
 
 Example ingress integrate command: 
 ```
@@ -65,8 +64,7 @@ _Supported charms_: [loki-k8s](https://charmhub.io/loki-k8s)
 The logging relation is a part of the COS relation to enhance logging observability.
 Logging relation through the `loki_push_api` interface installs and runs `promtail` which ships the
 contents of the Hockeypuck kubernetes pod logs to Loki.
-This can then be queried through the Loki API or easily visualized through Grafana. Learn more about COS
-[here](https://charmhub.io/topics/canonical-observability-stack).
+This can then be queried through the Loki API or easily visualized through Grafana. Learn more about COS in the [Canonical Observability Stack](https://charmhub.io/topics/canonical-observability-stack) documentation.
 
 Example logging-endpoint integrate command: 
 ```
@@ -92,7 +90,7 @@ _Interface_: [`traefik_route`](https://charmhub.io/traefik-k8s/integrations#trae
 _Supported charms_: [traefik-k8s](https://charmhub.io/traefik-k8s)
 
 The traefik-route relation provides low-level access to Traefik configuration. Hockeypuck requires 
-this interface to expose the reconciliation port (11370) to [peer](https://hockeypuck.io/configuration.html#:~:text=1.4.-,Recon,-Hockeypuck%20supports%20the) with other key servers.
+this interface to expose the reconciliation port (`11370`) to [peer](https://hockeypuck.io/configuration.html#:~:text=1.4.-,Recon,-Hockeypuck%20supports%20the) with other key servers.
 
 Example traefik-route integrate command: 
 ```

--- a/docs/reference/ports.md
+++ b/docs/reference/ports.md
@@ -2,6 +2,6 @@
 
 Hockeypuck exposes the following ports for its operation:
 
-1. **Web App port** (11371): This port serves the Hockeypuck web UI as well as its SKS-compatible APIs. It is made externally accessible when the charm is integrated with an ingress controller like traefik-k8s.
-2. **Reconciliation port** (11370): This port is used for peering with other SKS-compatible key servers to synchronize key data. It is accessible using the traefik-route relation.
+1. **Web App port** (`11371`): This port serves the Hockeypuck web UI as well as its SKS-compatible APIs. It is made externally accessible when the charm is integrated with an ingress controller like traefik-k8s.
+2. **Reconciliation port** (`11370`): This port is used for peering with other SKS-compatible key servers to synchronize key data. It is accessible using the traefik-route relation.
 3. **Metrics port** (9626): Hockeypuck exports Prometheus-compatible metrics at this port through the `/metrics` endpoint.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add landing pages
<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](`../docs/changelog.md`) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
