### PR TITLE
chore(renovate): add Renovate tracking for Hockeypuck workload version (charmkeeper)

### DIFF
--- a/hockeypuck_rock/rockcraft.yaml
+++ b/hockeypuck_rock/rockcraft.yaml
@@ -20,6 +20,7 @@ parts:
   hockeypuck:
     plugin: make
     source: https://github.com/hockeypuck/hockeypuck.git
+    # renovate: depName=hockeypuck/hockeypuck
     source-tag: 2.2.3
     source-type: git
     source-depth: 1

--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,18 @@
     },
     {
       "customType": "regex",
+      "datasourceTemplate": "github-tags",
+      "description": "Update Hockeypuck workload version from git tags",
+      "fileMatch": [
+        "hockeypuck_rock/rockcraft.yaml"
+      ],
+      "matchStrings": [
+        "# renovate: depName=(?<depName>.*?)\\n\\s+source-tag:\\s(?<currentValue>.*)"
+      ],
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
       "datasourceTemplate": "custom.charmhub",
       "fileMatch": [
         "\\.tftest\\.hcl$",


### PR DESCRIPTION
## Summary

Trivy is currently disabled for all pipelines. To maintain rocks in good shape, we need Renovate to track upstream workload versions so we are notified when new versions are available.

This PR adds Renovate tracking for the Hockeypuck workload version used in the rock build.

### Changes
- **`hockeypuck_rock/rockcraft.yaml`**: Added `# renovate: depName=hockeypuck/hockeypuck` annotation above `source-tag` so Renovate can detect the current version.
- **`renovate.json`**: Added a `customManager` targeting `hockeypuck_rock/rockcraft.yaml` to track new git tags from `hockeypuck/hockeypuck` on GitHub and propose updates to `source-tag`.

### Reference
- Jira: ISD-5553
- Example: [synapse-operator renovate.json](https://github.com/canonical/synapse-operator/blob/2/main/renovate.json)