### PR TITLE
chore(ci): add auto_update_libs bulk permission fixer

### DIFF
--- a/automation/auto_update_libs_targets.yaml
+++ b/automation/auto_update_libs_targets.yaml
@@ -1,0 +1,224 @@
+generated_at: "2026-07-20T18:00:00Z"
+org: canonical
+selection_criteria:
+  topics:
+    - charm
+    - platform-engineering
+  workflow_name: Auto-update charm libraries
+  failure_conclusion: startup_failure
+  min_consecutive_failures: 7
+issue_summary: >
+  Repositories listed here have a long-running startup_failure streak on the
+  auto-update charm libraries workflow, typically caused by missing explicit
+  workflow caller permissions when repo default workflow permissions are read-only.
+repos:
+  - name: canonical/github-runner-operator
+    url: https://github.com/canonical/github-runner-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:38:21Z"
+    latest_failure_at: "2026-07-20T01:34:05Z"
+    latest_run_url: https://github.com/canonical/github-runner-operator/actions/runs/29711107285
+  - name: canonical/wordpress-k8s-operator
+    url: https://github.com/canonical/wordpress-k8s-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:42:28Z"
+    latest_failure_at: "2026-07-20T01:38:43Z"
+    latest_run_url: https://github.com/canonical/wordpress-k8s-operator/actions/runs/29711224477
+  - name: canonical/indico-operator
+    url: https://github.com/canonical/indico-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:45:50Z"
+    latest_failure_at: "2026-07-20T01:45:07Z"
+    latest_run_url: https://github.com/canonical/indico-operator/actions/runs/29711380940
+  - name: canonical/synapse-operator
+    url: https://github.com/canonical/synapse-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:39:58Z"
+    latest_failure_at: "2026-07-20T01:35:54Z"
+    latest_run_url: https://github.com/canonical/synapse-operator/actions/runs/29711157842
+  - name: canonical/wazuh-server-operator
+    url: https://github.com/canonical/wazuh-server-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:46:06Z"
+    latest_failure_at: "2026-07-20T01:45:59Z"
+    latest_run_url: https://github.com/canonical/wazuh-server-operator/actions/runs/29711404009
+  - name: canonical/haproxy-operator
+    url: https://github.com/canonical/haproxy-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:35:35Z"
+    latest_failure_at: "2026-07-20T01:31:06Z"
+    latest_run_url: https://github.com/canonical/haproxy-operator/actions/runs/29711035529
+  - name: canonical/nginx-ingress-integrator-operator
+    url: https://github.com/canonical/nginx-ingress-integrator-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:38:18Z"
+    latest_failure_at: "2026-07-20T01:34:01Z"
+    latest_run_url: https://github.com/canonical/nginx-ingress-integrator-operator/actions/runs/29711105827
+  - name: canonical/jenkins-k8s-operator
+    url: https://github.com/canonical/jenkins-k8s-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:44:03Z"
+    latest_failure_at: "2026-07-20T01:40:29Z"
+    latest_run_url: https://github.com/canonical/jenkins-k8s-operator/actions/runs/29711267046
+  - name: canonical/gateway-api-integrator-operator
+    url: https://github.com/canonical/gateway-api-integrator-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:38:57Z"
+    latest_failure_at: "2026-07-20T01:34:35Z"
+    latest_run_url: https://github.com/canonical/gateway-api-integrator-operator/actions/runs/29711121020
+  - name: canonical/jenkins-agent-operator
+    url: https://github.com/canonical/jenkins-agent-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:45:54Z"
+    latest_failure_at: "2026-07-20T01:45:09Z"
+    latest_run_url: https://github.com/canonical/jenkins-agent-operator/actions/runs/29711381946
+  - name: canonical/netbox-k8s-operator
+    url: https://github.com/canonical/netbox-k8s-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:46:25Z"
+    latest_failure_at: "2026-07-20T01:46:06Z"
+    latest_run_url: https://github.com/canonical/netbox-k8s-operator/actions/runs/29711406663
+  - name: canonical/opencti-operator
+    url: https://github.com/canonical/opencti-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:38:24Z"
+    latest_failure_at: "2026-07-20T01:34:01Z"
+    latest_run_url: https://github.com/canonical/opencti-operator/actions/runs/29711105645
+  - name: canonical/aproxy-operator
+    url: https://github.com/canonical/aproxy-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:38:55Z"
+    latest_failure_at: "2026-07-20T01:34:29Z"
+    latest_run_url: https://github.com/canonical/aproxy-operator/actions/runs/29711118664
+  - name: canonical/github-runner-image-builder-operator
+    url: https://github.com/canonical/github-runner-image-builder-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:42:04Z"
+    latest_failure_at: "2026-07-20T01:37:58Z"
+    latest_run_url: https://github.com/canonical/github-runner-image-builder-operator/actions/runs/29711207243
+  - name: canonical/ingress-configurator-operator
+    url: https://github.com/canonical/ingress-configurator-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:39:43Z"
+    latest_failure_at: "2026-07-20T01:35:40Z"
+    latest_run_url: https://github.com/canonical/ingress-configurator-operator/actions/runs/29711152063
+  - name: canonical/maubot-operator
+    url: https://github.com/canonical/maubot-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:40:46Z"
+    latest_failure_at: "2026-07-20T01:36:48Z"
+    latest_run_url: https://github.com/canonical/maubot-operator/actions/runs/29711180011
+  - name: canonical/http-proxy-operators
+    url: https://github.com/canonical/http-proxy-operators
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:44:21Z"
+    latest_failure_at: "2026-07-20T01:41:42Z"
+    latest_run_url: https://github.com/canonical/http-proxy-operators/actions/runs/29711295538
+  - name: canonical/wireguard-gateway-operator
+    url: https://github.com/canonical/wireguard-gateway-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:43:10Z"
+    latest_failure_at: "2026-07-20T01:39:22Z"
+    latest_run_url: https://github.com/canonical/wireguard-gateway-operator/actions/runs/29711239480
+  - name: canonical/smtp-integrator-operator
+    url: https://github.com/canonical/smtp-integrator-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:37:20Z"
+    latest_failure_at: "2026-07-20T01:33:27Z"
+    latest_run_url: https://github.com/canonical/smtp-integrator-operator/actions/runs/29711092552
+  - name: canonical/dns-operators
+    url: https://github.com/canonical/dns-operators
+    workflow_path: .github/workflows/auto-update-libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:42:37Z"
+    latest_failure_at: "2026-07-20T01:38:41Z"
+    latest_run_url: https://github.com/canonical/dns-operators/actions/runs/29711223802
+  - name: canonical/falco-operators
+    url: https://github.com/canonical/falco-operators
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:42:37Z"
+    latest_failure_at: "2026-07-20T01:38:18Z"
+    latest_run_url: https://github.com/canonical/falco-operators/actions/runs/29711215300
+  - name: canonical/backup-operators
+    url: https://github.com/canonical/backup-operators
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:44:44Z"
+    latest_failure_at: "2026-07-20T01:41:31Z"
+    latest_run_url: https://github.com/canonical/backup-operators/actions/runs/29711291222
+  - name: canonical/content-cache-operator
+    url: https://github.com/canonical/content-cache-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:42:17Z"
+    latest_failure_at: "2026-07-20T01:38:02Z"
+    latest_run_url: https://github.com/canonical/content-cache-operator/actions/runs/29711208974
+  - name: canonical/saml-integrator-operator
+    url: https://github.com/canonical/saml-integrator-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:41:50Z"
+    latest_failure_at: "2026-07-20T01:37:52Z"
+    latest_run_url: https://github.com/canonical/saml-integrator-operator/actions/runs/29711205072
+  - name: canonical/penpot-operator
+    url: https://github.com/canonical/penpot-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:44:02Z"
+    latest_failure_at: "2026-07-20T01:40:18Z"
+    latest_run_url: https://github.com/canonical/penpot-operator/actions/runs/29711262455
+  - name: canonical/hockeypuck-k8s-operator
+    url: https://github.com/canonical/hockeypuck-k8s-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:41:47Z"
+    latest_failure_at: "2026-07-20T01:37:42Z"
+    latest_run_url: https://github.com/canonical/hockeypuck-k8s-operator/actions/runs/29711200945
+  - name: canonical/opendkim-operator
+    url: https://github.com/canonical/opendkim-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:39:15Z"
+    latest_failure_at: "2026-07-20T01:34:46Z"
+    latest_run_url: https://github.com/canonical/opendkim-operator/actions/runs/29711125886
+  - name: canonical/mailserver-operators
+    url: https://github.com/canonical/mailserver-operators
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:37:01Z"
+    latest_failure_at: "2026-07-20T01:33:19Z"
+    latest_run_url: https://github.com/canonical/mailserver-operators/actions/runs/29711089332
+  - name: canonical/ubuntu-motd-server-operator
+    url: https://github.com/canonical/ubuntu-motd-server-operator
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:36:54Z"
+    latest_failure_at: "2026-07-20T01:32:28Z"
+    latest_run_url: https://github.com/canonical/ubuntu-motd-server-operator/actions/runs/29711067837
+  - name: canonical/postfix-relay-operators
+    url: https://github.com/canonical/postfix-relay-operators
+    workflow_path: .github/workflows/auto_update_libs.yaml
+    failure_streak: 61
+    first_failure_at: "2026-05-21T01:37:05Z"
+    latest_failure_at: "2026-07-20T01:32:46Z"
+    latest_run_url: https://github.com/canonical/postfix-relay-operators/actions/runs/29711075032

--- a/scripts/fix_auto_update_libs.sh
+++ b/scripts/fix_auto_update_libs.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/fix_auto_update_libs.sh [options]
+
+Options:
+  --inventory <path>      YAML inventory file (default: automation/auto_update_libs_targets.yaml)
+  --repo <owner/name>     Process one repo only
+  --branch-prefix <text>  Branch name prefix (default: fix/auto-update-libs-permissions)
+  --dry-run               Do all local steps except push and PR creation
+  -h, --help              Show this help
+EOF
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+inventory="automation/auto_update_libs_targets.yaml"
+repo_filter=""
+branch_prefix="fix/auto-update-libs-permissions"
+dry_run=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --inventory)
+      inventory="$2"
+      shift 2
+      ;;
+    --repo)
+      repo_filter="$2"
+      shift 2
+      ;;
+    --branch-prefix)
+      branch_prefix="$2"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+require_cmd git
+require_cmd gh
+require_cmd python3
+
+if [[ ! -f "$inventory" ]]; then
+  echo "Inventory file not found: $inventory" >&2
+  exit 1
+fi
+
+extract_targets() {
+  python3 - "$inventory" "$repo_filter" <<'PY'
+import json
+import sys
+from pathlib import Path
+import yaml
+
+inventory_path = Path(sys.argv[1])
+repo_filter = sys.argv[2]
+data = yaml.safe_load(inventory_path.read_text())
+repos = data.get("repos", [])
+
+for repo in repos:
+    if repo_filter and repo.get("name") != repo_filter:
+        continue
+    print(json.dumps({
+        "name": repo["name"],
+        "url": repo["url"],
+        "workflow_path": repo["workflow_path"],
+        "latest_run_url": repo.get("latest_run_url", ""),
+        "failure_streak": repo.get("failure_streak", ""),
+    }))
+PY
+}
+
+targets="$(extract_targets)"
+if [[ -z "$targets" ]]; then
+  echo "No matching targets found."
+  exit 1
+fi
+
+echo "Starting auto_update_libs permission fix run"
+echo "Inventory: $inventory"
+if [[ -n "$repo_filter" ]]; then
+  echo "Filtered repo: $repo_filter"
+fi
+echo
+
+while IFS= read -r target; do
+  [[ -z "$target" ]] && continue
+
+  name="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["name"])' "$target")"
+  workflow_path="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["workflow_path"])' "$target")"
+  latest_run_url="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("latest_run_url",""))' "$target")"
+  failure_streak="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("failure_streak",""))' "$target")"
+  repo_short="${name#*/}"
+  branch="${branch_prefix}-${repo_short}"
+
+  echo "=== Processing $name ==="
+  tmpdir="$(mktemp -d)"
+
+  gh repo clone "$name" "$tmpdir/repo" -- --quiet
+  cd "$tmpdir/repo"
+
+  if [[ ! -f "$workflow_path" ]]; then
+    echo "Workflow file not found: $workflow_path"
+    cd - >/dev/null
+    rm -rf "$tmpdir"
+    continue
+  fi
+
+  git checkout -b "$branch"
+
+  set +e
+  python3 - "$workflow_path" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text()
+
+if "id-token: write" in text and "pull-requests: write" in text and "contents: write" in text:
+    print("Permissions already present.")
+    raise SystemExit(10)
+
+needle = (
+    "    uses: canonical/operator-workflows/.github/workflows/auto_update_charm_libs.yaml@main\n"
+    "    secrets: inherit\n"
+)
+replacement = (
+    "    uses: canonical/operator-workflows/.github/workflows/auto_update_charm_libs.yaml@main\n"
+    "    permissions:\n"
+    "      contents: write\n"
+    "      pull-requests: write\n"
+    "      id-token: write\n"
+    "    secrets: inherit\n"
+)
+
+if needle not in text:
+    raise SystemExit(f"Could not find expected workflow pattern in {path}")
+
+path.write_text(text.replace(needle, replacement, 1))
+print("Workflow permissions patch applied.")
+PY
+  patch_status=$?
+  set -e
+  if [[ $patch_status -eq 10 ]]; then
+    echo "No change needed."
+    cd - >/dev/null
+    rm -rf "$tmpdir"
+    continue
+  elif [[ $patch_status -ne 0 ]]; then
+    echo "Failed to patch $workflow_path in $name"
+    cd - >/dev/null
+    rm -rf "$tmpdir"
+    continue
+  fi
+
+  grep -q "permissions:" "$workflow_path"
+  grep -q "contents: write" "$workflow_path"
+  grep -q "pull-requests: write" "$workflow_path"
+  grep -q "id-token: write" "$workflow_path"
+  python3 - <<'PY' "$workflow_path"
+import sys
+from pathlib import Path
+import yaml
+yaml.safe_load(Path(sys.argv[1]).read_text())
+print("YAML parse check passed.")
+PY
+
+  git add "$workflow_path"
+  git commit -m "fix(ci): grant reusable workflow write permissions"
+
+  if [[ "$dry_run" -eq 1 ]]; then
+    echo "Dry run: skipping push and PR creation for $name"
+  else
+    git push -u origin "$branch"
+    gh pr create \
+      --base main \
+      --head "$branch" \
+      --title "fix(ci): grant permissions for auto_update_libs reusable workflow" \
+      --body "$(cat <<EOF
+## Summary
+- add explicit permissions to \`$workflow_path\`
+- grant \`contents: write\`, \`pull-requests: write\`, and \`id-token: write\` to the reusable-workflow caller job
+
+## Why
+The auto-update libraries workflow has a long startup-failure streak (${failure_streak} runs).  
+Latest failed run: ${latest_run_url}
+
+This repository uses read-only default workflow token permissions, but the called reusable workflow requires write scopes.
+
+## Resolution
+Add explicit caller permissions so scheduled runs can start and create update PRs successfully.
+EOF
+)"
+  fi
+
+  cd - >/dev/null
+  rm -rf "$tmpdir"
+  echo "Completed $name"
+  echo
+done <<< "$targets"
+
+echo "Done."


### PR DESCRIPTION
## Summary
- add `automation/auto_update_libs_targets.yaml` with affected canonical charm/platform-engineering repos and failure metadata
- add `scripts/fix_auto_update_libs.sh` to clone one repo at a time in a temporary directory, patch workflow permissions, verify the file, push a branch, and open a PR
- support targeting a single repo with `--repo`, plus `--dry-run`

## Validation
- `bash -n scripts/fix_auto_update_libs.sh`
- YAML inventory parses and includes 30 repos
- dry run: `scripts/fix_auto_update_libs.sh --repo canonical/indico-operator --dry-run`
- live validation: opened canonical/indico-operator#775